### PR TITLE
Fix typo, wrong http method and add working stopID

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Returns route map details
   Returns Nearest routes details
   * **URL**
 
-    `/busstops/stopnearby/lat/:lat/lon/:lan/rad/2`
+    `/busstops/stopnearby/lat/:lat/lon/:lon/rad/2`
 
   * **Method:**
 
@@ -129,12 +129,12 @@ Returns route map details
     `http://bmtcmob.hostg.in/api/itsstopwise/details`
   * **Method**
 
-    `GET`
+    `POST`
   * **Data Params**
 
     ```javascript
     {
-    "stopID" : '9235'
+    "stopID" : '9234'
     }
     ```
 


### PR DESCRIPTION
- The http method for 'stop details' is appeared to be POST (not GET)
- stopID 9235 returns a 404, but 9234 is a working example.
- Minor change in the variable name 'lon' instead of 'lan' which is referring the longitude. ;)
